### PR TITLE
Participants last_responded formatting and rankings time formatting

### DIFF
--- a/app/views/matchings/show.html.erb
+++ b/app/views/matchings/show.html.erb
@@ -6,18 +6,16 @@
 
 <% if @matching %>
 
-<table style="width:100%">
+<table class="table">
 	<tbody>
 	<tr>
     <td><b>Time</b></td>
-		<td><b>Event</b></td>
 		<td><b>People</b></td>
 	</tr>
 
   <% @parsed_matching["schedule"].each do |event|  %>
     <tr>
-      <td><%= event["timestamp"] %></td>
-      <td><%= event["event_name"] %></td>
+      <td><%= Time.parse(event["timestamp"]).strftime("%A, %B %d %Y %I:%M %p") %></td>
       <td><%= event["people_called"].join(', ') %> </td>
     </tr>
 

--- a/app/views/participants/display.html.erb
+++ b/app/views/participants/display.html.erb
@@ -7,7 +7,7 @@
 
   <h1>Listing Participants</h1>
   <%= form_for(@participant, :url => project_participants_path) do |f| %>
-    <table style="width:100%">
+    <table class="table">
       <thead>
         <tr>
           <th>Participant Email</th>
@@ -20,10 +20,12 @@
       <% @participants.each do |participant| %>
         <tr>
           <td><%= participant.email %></td>
-          <td><%= participant.last_responded ? participant.last_responded : 'No response yet'%></td>
-          <td><%= link_to 'Autofill Rankings', autofill_project_participant_path(participant.project_id, participant.id), class:"btn btn-primary"%></td>
-          <td><%= link_to 'DELETE', project_participant_path(participant.project_id, participant.id), method: :delete, url: project_participants_path, class:"btn btn-danger"%></td>
-          <td><%= link_to 'Show Rankings', project_participant_ranking_path(participant.project_id, participant.id), class:"btn btn-success" %></td>
+          <td><%= participant.last_responded ? time_ago_in_words(participant.last_responded) + ' ago' : 'No response yet'%></td>
+          <td>
+            <%= link_to 'Autofill Rankings', autofill_project_participant_path(participant.project_id, participant.id), class:"btn btn-primary"%>
+            <%= link_to 'DELETE', project_participant_path(participant.project_id, participant.id), method: :delete, url: project_participants_path, class:"btn btn-danger"%>
+            <%= link_to 'Show Rankings', project_participant_ranking_path(participant.project_id, participant.id), class:"btn btn-success" %>
+          </td>
         </tr>
       <% end %>
       </tbody>

--- a/features/see_matchings.feature
+++ b/features/see_matchings.feature
@@ -18,10 +18,10 @@ Feature: See Rankings
 
     Scenario: User views matchings for a project they do have access to
         When I access the matchings page for project of id "1"
-        Then I should see /Time(\s*)Event(\s*)People/
-        Then I should see /Fri, 22 Mar 2019 13:00:00 GMT(\s*)Person3-0(\s*)Person3/
-        Then I should see /Fri, 22 Mar 2019 14:00:00 GMT(\s*)Person1-0(\s*)Person1/
-        Then I should see /Fri, 22 Mar 2019 15:00:00 GMT(\s*)Person2-0(\s*)Person2/
+        Then I should see /Time(\s*)People/
+        Then I should see /Friday, March 22 2019 01:00 PM(\s*)Person3/
+        Then I should see /Friday, March 22 2019 02:00 PM(\s*)Person1/
+        Then I should see /Friday, March 22 2019 03:00 PM(\s*)Person2/
 
     Scenario: User tries to view matchings for a project with no matchings yet
         When I am on the matchings page for project of id "2"


### PR DESCRIPTION
- participants last_responded now shows "time ago" format e.g. "3 hours ago" instead of "2019-05-02 16:59:53 UTC"
- matchings table no longer shows "GMT". e.g. now it shows "Friday, March 22 2019 08:00 PM" instead of "Fri, 22 March 2019 20:00:00 GMT"
- participants and matchings table both use Bootstrap table style
- removed events from rankings table