### PR TITLE
ability to recognize '0' ranking, test case

### DIFF
--- a/app/controllers/matchings_controller.rb
+++ b/app/controllers/matchings_controller.rb
@@ -140,8 +140,10 @@ class MatchingsController < ApplicationController
       person = ranking.participant.email
       timeslot = ranking.project_time.date_time
       timeslot_formatted = timeslot.strftime('%Y-%m-%d %H:%M')
-      row = {"person_name": person, "timeslot": timeslot_formatted, "rank": ranking.rank}
-      preferences.push(row)
+      if ranking.rank != 0
+        row = {"person_name": person, "timeslot": timeslot_formatted, "rank": ranking.rank}
+        preferences.push(row)
+      end
     end
 
     preferences

--- a/features/match.feature
+++ b/features/match.feature
@@ -81,3 +81,13 @@ Feature: Match
     And I should see "Matching Complete."
     Then I press "Run algorithm again"
     And I should see "Matching Complete. All users successfully matched."
+
+   Scenario: User is warned when no users are matched
+    Given 5 people submitted negative preferences for "CS61A Sections"
+    When I am on the matchings page for "CS61A Sections"
+    Then I should see "Ready to match."
+    And I press "Match!"
+    Then I should be on the matchings page for "CS61A Sections"
+    And I should see "Matching Complete."
+    Then I press "Run algorithm again"
+    And I should see "Matching Complete. addison.chan@berkeley.edu, alexstennet@berkeley.edu, andrew.huang@berkeley.edu, annietang@berkeley.edu, tperumpail@berkeley.edu did not receive a match."


### PR DESCRIPTION
Responds properly to values of '0' for preferences by just not submitting a preference for that specific time and person to the API, since the API itself isn't equipped to handle preference values of 0.