### PR TITLE
add consistency checking and tests

### DIFF
--- a/features/enter_preferences.feature
+++ b/features/enter_preferences.feature
@@ -53,7 +53,7 @@ Background: A project is set up and participants are invited to rank times
     Then I am on the project participants page for "empoleon@berkeley.edu" for project "CS169 Sections"
     And I fill in "Match Degree" with "2"
     And I press "Update Participant"
-    Then I should see "Participant was successfully updated."
+    Then I should see "Successfully updated participant"
     Then I am on the participants page for "CS169 Sections"
     And the match degree of "empoleon@berkeley.edu" should be 2
 

--- a/features/match.feature
+++ b/features/match.feature
@@ -121,3 +121,17 @@ Feature: Match
     And I should see "Matching Complete."
     Then I press "Run algorithm again"
     And I should see "All users successfully matched."
+
+  Scenario: User warned if there are too few times to successfully match to everyone if adding new person
+    When I fill in "Email" with "duckywucky@berkeley.edu"
+    And I fill in "Match Degree" with "1"
+    And press "Add Participant"
+    Then I should see "Successfully created participant"
+    Then I should see "Not everyone will receive a match."
+
+  Scenario: User warned if there are too few times to successfully match to everyone if editing match degree
+    Then I am on the project participants page for "alexstennet@berkeley.edu" for project "CS61A Sections"
+    And I fill in "Match Degree" with "2"
+    And I press "Update Participant"
+    Then I should see "Successfully updated participant"
+    Then I should see "Not everyone will receive a match."

--- a/features/multi_degree_match.feature
+++ b/features/multi_degree_match.feature
@@ -66,7 +66,7 @@ Feature: Multi-degree Matching
     Then I am on the project participants page for "alexstennet@berkeley.edu" for project "CS61A Sections"
     And I fill in "Match Degree" with "2"
     And I press "Update Participant"
-    Then I should see "Participant was successfully updated."
+    Then I should see "Successfully updated participant"
     Then I am on the participants page for "CS61A Sections"
     And the match degree of "alexstennet@berkeley.edu" should be 2
 


### PR DESCRIPTION
when adding or updating a participant's match degree, if there are fewer timeslots available than is necessary (sum of all match degree) then the user will get a message saying that they've successfully saved, but will need to add more times.